### PR TITLE
feat: Add glob, grep, file_editor, and apply_patch tools to SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,10 +1158,13 @@ dependencies = [
  "glob",
  "lazy_static",
  "rand",
+ "regex",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
+ "similar",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1396,6 +1399,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1840,6 +1855,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/openhands-sdk-rs/Cargo.toml
+++ b/openhands-sdk-rs/Cargo.toml
@@ -10,9 +10,11 @@ chrono = { version = "0.4.42", features = ["serde"] }
 genai = "0.4.4"
 glob = "0.3.3"
 rand = "0.9.2"
+regex = "1.10"
 reqwest = { version = "0.13.1", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
+similar = "2.4"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.41"
@@ -24,4 +26,5 @@ lazy_static = "1.5.0"
 
 [dev-dependencies]
 dotenv = "0.15.0"
+tempfile = "3.8"
 tokio = { version = "1.48.0", features = ["full"] }

--- a/openhands-sdk-rs/src/agent/tools.rs
+++ b/openhands-sdk-rs/src/agent/tools.rs
@@ -1,3 +1,13 @@
+mod apply_patch;
+mod file_editor;
+mod glob;
+mod grep;
+
+pub use apply_patch::ApplyPatchTool;
+pub use file_editor::FileEditorTool;
+pub use glob::GlobTool;
+pub use grep::GrepTool;
+
 use async_trait::async_trait;
 use serde_json::Value;
 use std::process::Command;

--- a/openhands-sdk-rs/src/agent/tools/apply_patch.rs
+++ b/openhands-sdk-rs/src/agent/tools/apply_patch.rs
@@ -1,0 +1,382 @@
+use async_trait::async_trait;
+use serde_json::Value;
+use std::path::PathBuf;
+
+use super::Tool;
+
+pub struct ApplyPatchTool {
+    working_dir: PathBuf,
+}
+
+impl ApplyPatchTool {
+    pub fn new(working_dir: PathBuf) -> Self {
+        Self { working_dir }
+    }
+
+    fn parse_patch(&self, patch_text: &str) -> Result<Vec<FilePatch>, String> {
+        let lines: Vec<&str> = patch_text.lines().collect();
+        let mut patches = Vec::new();
+        let mut i = 0;
+
+        // Find "*** Begin Patch" marker
+        while i < lines.len() {
+            if lines[i].trim() == "*** Begin Patch" {
+                i += 1;
+                break;
+            }
+            i += 1;
+        }
+
+        if i == 0 || i >= lines.len() {
+            return Err("Patch must start with '*** Begin Patch'".to_string());
+        }
+
+        // Parse file patches until "*** End Patch"
+        while i < lines.len() {
+            if lines[i].trim() == "*** End Patch" {
+                break;
+            }
+
+            // Look for file header (e.g., "--- a/path/to/file.txt")
+            if lines[i].starts_with("--- ") {
+                let old_file = lines[i]
+                    .strip_prefix("--- ")
+                    .and_then(|s| s.strip_prefix("a/"))
+                    .unwrap_or(&lines[i][4..])
+                    .trim();
+
+                i += 1;
+                if i >= lines.len() || !lines[i].starts_with("+++ ") {
+                    return Err("Expected '+++ ' line after '--- ' line".to_string());
+                }
+
+                let new_file = lines[i]
+                    .strip_prefix("+++ ")
+                    .and_then(|s| s.strip_prefix("b/"))
+                    .unwrap_or(&lines[i][4..])
+                    .trim();
+
+                i += 1;
+
+                // Parse hunks for this file
+                let mut hunks = Vec::new();
+                while i < lines.len()
+                    && !lines[i].starts_with("---")
+                    && lines[i].trim() != "*** End Patch"
+                {
+                    if lines[i].starts_with("@@ ") {
+                        // Parse hunk header
+                        let hunk_start = i;
+                        i += 1;
+
+                        // Collect hunk lines
+                        let mut hunk_lines = Vec::new();
+                        while i < lines.len()
+                            && !lines[i].starts_with("@@")
+                            && !lines[i].starts_with("---")
+                            && lines[i].trim() != "*** End Patch"
+                        {
+                            hunk_lines.push(lines[i].to_string());
+                            i += 1;
+                        }
+
+                        hunks.push(Hunk {
+                            header: lines[hunk_start].to_string(),
+                            lines: hunk_lines,
+                        });
+                    } else {
+                        i += 1;
+                    }
+                }
+
+                patches.push(FilePatch {
+                    old_path: old_file.to_string(),
+                    new_path: new_file.to_string(),
+                    hunks,
+                });
+            } else {
+                i += 1;
+            }
+        }
+
+        if patches.is_empty() {
+            return Err("No valid patches found in input".to_string());
+        }
+
+        Ok(patches)
+    }
+
+    fn apply_file_patch(&self, file_patch: &FilePatch) -> Result<String, String> {
+        let file_path = self.working_dir.join(&file_patch.new_path);
+
+        // Read existing file or start with empty content
+        let original_content = if file_path.exists() {
+            std::fs::read_to_string(&file_path)
+                .map_err(|e| format!("Failed to read '{}': {}", file_patch.new_path, e))?
+        } else {
+            String::new()
+        };
+
+        let mut lines: Vec<String> = original_content.lines().map(|s| s.to_string()).collect();
+
+        // Apply each hunk
+        for hunk in &file_patch.hunks {
+            self.apply_hunk(&mut lines, hunk)?;
+        }
+
+        // Write modified content
+        let new_content = lines.join("\n");
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create directory: {}", e))?;
+        }
+
+        std::fs::write(&file_path, &new_content)
+            .map_err(|e| format!("Failed to write '{}': {}", file_patch.new_path, e))?;
+
+        Ok(format!("Applied patch to '{}'", file_patch.new_path))
+    }
+
+    fn apply_hunk(&self, lines: &mut Vec<String>, hunk: &Hunk) -> Result<(), String> {
+        // Parse hunk header to get line numbers
+        // Format: @@ -old_start,old_count +new_start,new_count @@
+        let header_parts: Vec<&str> = hunk.header.split_whitespace().collect();
+        if header_parts.len() < 3 {
+            return Err(format!("Invalid hunk header: {}", hunk.header));
+        }
+
+        let old_range = header_parts[1].trim_start_matches('-');
+        let old_start: usize = old_range
+            .split(',')
+            .next()
+            .and_then(|s| s.parse().ok())
+            .ok_or("Invalid old line number")?;
+
+        // Build expected and new content from hunk
+        let mut expected_lines = Vec::new();
+        let mut new_lines = Vec::new();
+
+        for line in &hunk.lines {
+            if line.is_empty() {
+                continue;
+            }
+
+            let first_char = line.chars().next().unwrap();
+            let content = if line.len() > 1 { &line[1..] } else { "" };
+
+            match first_char {
+                '-' => {
+                    expected_lines.push(content.to_string());
+                }
+                '+' => {
+                    new_lines.push(content.to_string());
+                }
+                ' ' => {
+                    expected_lines.push(content.to_string());
+                    new_lines.push(content.to_string());
+                }
+                _ => {}
+            }
+        }
+
+        // Find matching location (with fuzzy matching)
+        let start_idx = old_start.saturating_sub(1);
+        let end_idx = (start_idx + expected_lines.len()).min(lines.len());
+
+        // Check if lines match
+        let actual_lines: Vec<String> = if start_idx < lines.len() {
+            lines[start_idx..end_idx].to_vec()
+        } else {
+            Vec::new()
+        };
+
+        // Simple fuzzy matching: allow if at least 70% of lines match
+        let matching_lines = expected_lines
+            .iter()
+            .zip(actual_lines.iter())
+            .filter(|(exp, act)| exp.trim() == act.trim())
+            .count();
+
+        let match_ratio = if expected_lines.is_empty() {
+            1.0
+        } else {
+            matching_lines as f64 / expected_lines.len() as f64
+        };
+
+        if match_ratio < 0.7 {
+            return Err(format!(
+                "Hunk does not match file content ({}% match)",
+                (match_ratio * 100.0) as usize
+            ));
+        }
+
+        // Apply the change
+        lines.splice(start_idx..end_idx, new_lines);
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FilePatch {
+    #[allow(dead_code)]
+    old_path: String,
+    new_path: String,
+    hunks: Vec<Hunk>,
+}
+
+#[derive(Debug)]
+struct Hunk {
+    header: String,
+    lines: Vec<String>,
+}
+
+#[async_trait]
+impl Tool for ApplyPatchTool {
+    fn name(&self) -> String {
+        "apply_patch".to_string()
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "Apply unified text patches to files. Input must start with '*** Begin Patch' and end with '*** End Patch'. \
+            Your current working directory is: {}",
+            self.working_dir.display()
+        )
+    }
+
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "patch": {
+                    "type": "string",
+                    "description": "Patch content following the '*** Begin Patch' ... '*** End Patch' format"
+                }
+            },
+            "required": ["patch"]
+        })
+    }
+
+    async fn call(&self, args: Value) -> Result<String, String> {
+        let patch_text = args
+            .get("patch")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'patch' argument")?;
+
+        // Parse the patch
+        let file_patches = self.parse_patch(patch_text)?;
+
+        // Apply each file patch
+        let mut results = Vec::new();
+        for file_patch in &file_patches {
+            match self.apply_file_patch(file_patch) {
+                Ok(msg) => results.push(msg),
+                Err(e) => return Err(format!("Failed to apply patch: {}", e)),
+            }
+        }
+
+        Ok(format!(
+            "Successfully applied {} patch(es):\n{}",
+            results.len(),
+            results.join("\n")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_apply_patch_basic() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create original file
+        fs::write(temp_path.join("test.txt"), "line1\nline2\nline3\n").unwrap();
+
+        let tool = ApplyPatchTool::new(temp_path.to_path_buf());
+
+        let patch = r#"*** Begin Patch
+--- a/test.txt
++++ b/test.txt
+@@ -1,3 +1,3 @@
+ line1
+-line2
++modified_line2
+ line3
+*** End Patch"#;
+
+        let args = serde_json::json!({
+            "patch": patch
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("Successfully applied"));
+
+        let content = fs::read_to_string(temp_path.join("test.txt")).unwrap();
+        assert!(content.contains("modified_line2"));
+        assert!(!content.contains("line1\nline2\nline3"));
+        // Verify the structure is correct
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[1], "modified_line2");
+    }
+
+    #[tokio::test]
+    async fn test_apply_patch_add_lines() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("test.txt"), "line1\nline3\n").unwrap();
+
+        let tool = ApplyPatchTool::new(temp_path.to_path_buf());
+
+        let patch = r#"*** Begin Patch
+--- a/test.txt
++++ b/test.txt
+@@ -1,2 +1,3 @@
+ line1
++line2
+ line3
+*** End Patch"#;
+
+        let args = serde_json::json!({
+            "patch": patch
+        });
+
+        tool.call(args).await.unwrap();
+
+        let content = fs::read_to_string(temp_path.join("test.txt")).unwrap();
+        assert!(content.contains("line2"));
+    }
+
+    #[tokio::test]
+    async fn test_apply_patch_new_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        let tool = ApplyPatchTool::new(temp_path.to_path_buf());
+
+        let patch = r#"*** Begin Patch
+--- a/newfile.txt
++++ b/newfile.txt
+@@ -0,0 +1,2 @@
++line1
++line2
+*** End Patch"#;
+
+        let args = serde_json::json!({
+            "patch": patch
+        });
+
+        tool.call(args).await.unwrap();
+
+        let content = fs::read_to_string(temp_path.join("newfile.txt")).unwrap();
+        assert!(content.contains("line1"));
+        assert!(content.contains("line2"));
+    }
+}

--- a/openhands-sdk-rs/src/agent/tools/file_editor.rs
+++ b/openhands-sdk-rs/src/agent/tools/file_editor.rs
@@ -1,0 +1,445 @@
+use async_trait::async_trait;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use super::Tool;
+
+#[derive(Clone)]
+struct FileState {
+    content: String,
+    history: Vec<String>,
+}
+
+pub struct FileEditorTool {
+    working_dir: PathBuf,
+    file_states: Arc<Mutex<HashMap<String, FileState>>>,
+}
+
+impl FileEditorTool {
+    pub fn new(working_dir: PathBuf) -> Self {
+        Self {
+            working_dir,
+            file_states: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn get_or_load_file(&self, path: &str) -> Result<FileState, String> {
+        let mut states = self.file_states.lock().unwrap();
+
+        if let Some(state) = states.get(path) {
+            Ok(state.clone())
+        } else {
+            // Load file from disk
+            let full_path = self.working_dir.join(path);
+            let content = std::fs::read_to_string(&full_path)
+                .map_err(|e| format!("Failed to read file '{}': {}", path, e))?;
+
+            let state = FileState {
+                content: content.clone(),
+                history: vec![content],
+            };
+            states.insert(path.to_string(), state.clone());
+            Ok(state)
+        }
+    }
+
+    fn save_file_state(&self, path: &str, new_content: String) -> Result<(), String> {
+        let mut states = self.file_states.lock().unwrap();
+
+        if let Some(state) = states.get_mut(path) {
+            state.history.push(state.content.clone());
+            state.content = new_content.clone();
+        } else {
+            let state = FileState {
+                content: new_content.clone(),
+                history: vec![],
+            };
+            states.insert(path.to_string(), state);
+        }
+
+        // Write to disk
+        let full_path = self.working_dir.join(path);
+        if let Some(parent) = full_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create directory: {}", e))?;
+        }
+        std::fs::write(&full_path, new_content)
+            .map_err(|e| format!("Failed to write file '{}': {}", path, e))?;
+
+        Ok(())
+    }
+
+    fn view_operation(&self, path: &str, start_line: Option<usize>, end_line: Option<usize>) -> Result<String, String> {
+        let state = self.get_or_load_file(path)?;
+        let lines: Vec<&str> = state.content.lines().collect();
+
+        let start = start_line.unwrap_or(1).saturating_sub(1);
+        let end = end_line.unwrap_or(lines.len()).min(lines.len());
+
+        if start >= lines.len() {
+            return Err(format!("Start line {} is beyond file length {}", start + 1, lines.len()));
+        }
+
+        let view_lines: Vec<String> = lines[start..end]
+            .iter()
+            .enumerate()
+            .map(|(i, line)| format!("{:4} | {}", start + i + 1, line))
+            .collect();
+
+        Ok(format!(
+            "Viewing '{}' (lines {}-{}):\n{}",
+            path,
+            start + 1,
+            end,
+            view_lines.join("\n")
+        ))
+    }
+
+    fn insert_operation(&self, path: &str, line: usize, content: &str) -> Result<String, String> {
+        let state = self.get_or_load_file(path)?;
+        let mut lines: Vec<String> = state.content.lines().map(|s| s.to_string()).collect();
+
+        let insert_pos = line.saturating_sub(1).min(lines.len());
+        let new_lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+
+        for (i, new_line) in new_lines.iter().enumerate() {
+            lines.insert(insert_pos + i, new_line.clone());
+        }
+
+        let new_content = lines.join("\n");
+        if !state.content.is_empty() && !new_content.ends_with('\n') {
+            self.save_file_state(path, format!("{}\n", new_content))?;
+        } else {
+            self.save_file_state(path, new_content)?;
+        }
+
+        Ok(format!(
+            "Inserted {} line(s) at line {} in '{}'",
+            new_lines.len(),
+            line,
+            path
+        ))
+    }
+
+    fn replace_operation(
+        &self,
+        path: &str,
+        start_line: usize,
+        end_line: usize,
+        content: &str,
+    ) -> Result<String, String> {
+        let state = self.get_or_load_file(path)?;
+        let mut lines: Vec<String> = state.content.lines().map(|s| s.to_string()).collect();
+
+        let start = start_line.saturating_sub(1);
+        let end = end_line.min(lines.len());
+
+        if start >= lines.len() {
+            return Err(format!("Start line {} is beyond file length {}", start_line, lines.len()));
+        }
+
+        // Remove old lines
+        lines.drain(start..end);
+
+        // Insert new lines
+        let new_lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+        for (i, new_line) in new_lines.iter().enumerate() {
+            lines.insert(start + i, new_line.clone());
+        }
+
+        let new_content = lines.join("\n");
+        if !state.content.is_empty() && !new_content.ends_with('\n') {
+            self.save_file_state(path, format!("{}\n", new_content))?;
+        } else {
+            self.save_file_state(path, new_content)?;
+        }
+
+        Ok(format!(
+            "Replaced lines {}-{} with {} line(s) in '{}'",
+            start_line,
+            end_line,
+            new_lines.len(),
+            path
+        ))
+    }
+
+    fn delete_operation(&self, path: &str, start_line: usize, end_line: usize) -> Result<String, String> {
+        let state = self.get_or_load_file(path)?;
+        let mut lines: Vec<String> = state.content.lines().map(|s| s.to_string()).collect();
+
+        let start = start_line.saturating_sub(1);
+        let end = end_line.min(lines.len());
+
+        if start >= lines.len() {
+            return Err(format!("Start line {} is beyond file length {}", start_line, lines.len()));
+        }
+
+        let deleted_count = end - start;
+        lines.drain(start..end);
+
+        let new_content = lines.join("\n");
+        if !state.content.is_empty() && !new_content.ends_with('\n') {
+            self.save_file_state(path, format!("{}\n", new_content))?;
+        } else {
+            self.save_file_state(path, new_content)?;
+        }
+
+        Ok(format!(
+            "Deleted {} line(s) ({}-{}) from '{}'",
+            deleted_count, start_line, end_line, path
+        ))
+    }
+
+    fn undo_operation(&self, path: &str) -> Result<String, String> {
+        let mut states = self.file_states.lock().unwrap();
+
+        if let Some(state) = states.get_mut(path) {
+            if let Some(previous_content) = state.history.pop() {
+                state.content = previous_content.clone();
+
+                // Write to disk
+                let full_path = self.working_dir.join(path);
+                std::fs::write(&full_path, &previous_content)
+                    .map_err(|e| format!("Failed to write file '{}': {}", path, e))?;
+
+                Ok(format!("Undid last change to '{}'", path))
+            } else {
+                Err(format!("No history available for '{}'", path))
+            }
+        } else {
+            Err(format!("File '{}' not in edit session", path))
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for FileEditorTool {
+    fn name(&self) -> String {
+        "file_editor".to_string()
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "Structured file editing tool. Supports view, insert, replace, delete, and undo operations. \
+            Your current working directory is: {}",
+            self.working_dir.display()
+        )
+    }
+
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["view", "insert", "replace", "delete", "undo"],
+                    "description": "The operation to perform"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Relative path to the file"
+                },
+                "start_line": {
+                    "type": "integer",
+                    "description": "Starting line number (1-indexed, for view/replace/delete)"
+                },
+                "end_line": {
+                    "type": "integer",
+                    "description": "Ending line number (1-indexed, for view/replace/delete)"
+                },
+                "line": {
+                    "type": "integer",
+                    "description": "Line number for insert operation (1-indexed)"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to insert or replace"
+                }
+            },
+            "required": ["operation", "path"]
+        })
+    }
+
+    async fn call(&self, args: Value) -> Result<String, String> {
+        let operation = args
+            .get("operation")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'operation' argument")?;
+
+        let path = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'path' argument")?;
+
+        match operation {
+            "view" => {
+                let start_line = args.get("start_line").and_then(|v| v.as_u64()).map(|n| n as usize);
+                let end_line = args.get("end_line").and_then(|v| v.as_u64()).map(|n| n as usize);
+                self.view_operation(path, start_line, end_line)
+            }
+            "insert" => {
+                let line = args
+                    .get("line")
+                    .and_then(|v| v.as_u64())
+                    .ok_or("Missing 'line' argument for insert")? as usize;
+                let content = args
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .ok_or("Missing 'content' argument for insert")?;
+                self.insert_operation(path, line, content)
+            }
+            "replace" => {
+                let start_line = args
+                    .get("start_line")
+                    .and_then(|v| v.as_u64())
+                    .ok_or("Missing 'start_line' argument for replace")? as usize;
+                let end_line = args
+                    .get("end_line")
+                    .and_then(|v| v.as_u64())
+                    .ok_or("Missing 'end_line' argument for replace")? as usize;
+                let content = args
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .ok_or("Missing 'content' argument for replace")?;
+                self.replace_operation(path, start_line, end_line, content)
+            }
+            "delete" => {
+                let start_line = args
+                    .get("start_line")
+                    .and_then(|v| v.as_u64())
+                    .ok_or("Missing 'start_line' argument for delete")? as usize;
+                let end_line = args
+                    .get("end_line")
+                    .and_then(|v| v.as_u64())
+                    .ok_or("Missing 'end_line' argument for delete")? as usize;
+                self.delete_operation(path, start_line, end_line)
+            }
+            "undo" => self.undo_operation(path),
+            _ => Err(format!("Unknown operation: {}", operation)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_file_editor_view() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("test.txt"), "line1\nline2\nline3\n").unwrap();
+
+        let tool = FileEditorTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "operation": "view",
+            "path": "test.txt",
+            "start_line": 1,
+            "end_line": 2
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("line1"));
+        assert!(result.contains("line2"));
+        assert!(!result.contains("line3"));
+    }
+
+    #[tokio::test]
+    async fn test_file_editor_insert() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("test.txt"), "line1\nline3\n").unwrap();
+
+        let tool = FileEditorTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "operation": "insert",
+            "path": "test.txt",
+            "line": 2,
+            "content": "line2"
+        });
+
+        tool.call(args).await.unwrap();
+
+        let content = fs::read_to_string(temp_path.join("test.txt")).unwrap();
+        assert_eq!(content, "line1\nline2\nline3\n");
+    }
+
+    #[tokio::test]
+    async fn test_file_editor_replace() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("test.txt"), "line1\nline2\nline3\n").unwrap();
+
+        let tool = FileEditorTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "operation": "replace",
+            "path": "test.txt",
+            "start_line": 2,
+            "end_line": 2,
+            "content": "new_line2"
+        });
+
+        tool.call(args).await.unwrap();
+
+        let content = fs::read_to_string(temp_path.join("test.txt")).unwrap();
+        assert_eq!(content, "line1\nnew_line2\nline3\n");
+    }
+
+    #[tokio::test]
+    async fn test_file_editor_delete() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("test.txt"), "line1\nline2\nline3\n").unwrap();
+
+        let tool = FileEditorTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "operation": "delete",
+            "path": "test.txt",
+            "start_line": 2,
+            "end_line": 2
+        });
+
+        tool.call(args).await.unwrap();
+
+        let content = fs::read_to_string(temp_path.join("test.txt")).unwrap();
+        assert_eq!(content, "line1\nline3\n");
+    }
+
+    #[tokio::test]
+    async fn test_file_editor_undo() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("test.txt"), "original\n").unwrap();
+
+        let tool = FileEditorTool::new(temp_path.to_path_buf());
+
+        // Make a change
+        let args = serde_json::json!({
+            "operation": "replace",
+            "path": "test.txt",
+            "start_line": 1,
+            "end_line": 1,
+            "content": "modified"
+        });
+        tool.call(args).await.unwrap();
+
+        // Undo
+        let undo_args = serde_json::json!({
+            "operation": "undo",
+            "path": "test.txt"
+        });
+        tool.call(undo_args).await.unwrap();
+
+        let content = fs::read_to_string(temp_path.join("test.txt")).unwrap();
+        assert_eq!(content, "original\n");
+    }
+}

--- a/openhands-sdk-rs/src/agent/tools/glob.rs
+++ b/openhands-sdk-rs/src/agent/tools/glob.rs
@@ -1,0 +1,200 @@
+use async_trait::async_trait;
+use glob::glob;
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use super::Tool;
+
+pub struct GlobTool {
+    working_dir: PathBuf,
+}
+
+impl GlobTool {
+    pub fn new(working_dir: PathBuf) -> Self {
+        Self { working_dir }
+    }
+}
+
+#[async_trait]
+impl Tool for GlobTool {
+    fn name(&self) -> String {
+        "glob".to_string()
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "Fast file pattern matching tool. Supports glob patterns like '**/*.js' or 'src/**/*.ts'. \
+            Returns matching file paths sorted by modification time. \
+            Only the first 100 results are returned. \
+            Your current working directory is: {}",
+            self.working_dir.display()
+        )
+    }
+
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "The glob pattern to match files (e.g., '**/*.js', 'src/**/*.ts')"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Optional directory to search in (defaults to working directory)"
+                }
+            },
+            "required": ["pattern"]
+        })
+    }
+
+    async fn call(&self, args: Value) -> Result<String, String> {
+        let pattern = args
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'pattern' argument")?;
+
+        let search_path = if let Some(path_str) = args.get("path").and_then(|v| v.as_str()) {
+            PathBuf::from(path_str)
+        } else {
+            self.working_dir.clone()
+        };
+
+        // Validate search path
+        if !search_path.is_dir() {
+            return Err(format!(
+                "Search path '{}' is not a valid directory",
+                search_path.display()
+            ));
+        }
+
+        // Build full glob pattern
+        let full_pattern = search_path.join(pattern);
+        let pattern_str = full_pattern
+            .to_str()
+            .ok_or("Invalid path encoding")?;
+
+        // Execute glob search
+        let mut matches: Vec<(PathBuf, SystemTime)> = Vec::new();
+        
+        for entry in glob(pattern_str).map_err(|e| e.to_string())? {
+            match entry {
+                Ok(path) => {
+                    if path.is_file() {
+                        if let Ok(metadata) = fs::metadata(&path) {
+                            if let Ok(modified) = metadata.modified() {
+                                matches.push((path, modified));
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Glob error: {}", e);
+                }
+            }
+
+            // Limit to 100 files
+            if matches.len() >= 100 {
+                break;
+            }
+        }
+
+        // Sort by modification time (newest first)
+        matches.sort_by(|a, b| b.1.cmp(&a.1));
+
+        let truncated = matches.len() >= 100;
+        let file_paths: Vec<String> = matches
+            .into_iter()
+            .map(|(path, _)| path.to_string_lossy().to_string())
+            .collect();
+
+        // Format output
+        if file_paths.is_empty() {
+            Ok(format!(
+                "No files found matching pattern '{}' in directory '{}'",
+                pattern,
+                search_path.display()
+            ))
+        } else {
+            let mut output = format!(
+                "Found {} file(s) matching pattern '{}' in '{}':\n{}",
+                file_paths.len(),
+                pattern,
+                search_path.display(),
+                file_paths.join("\n")
+            );
+
+            if truncated {
+                output.push_str(
+                    "\n\n[Results truncated to first 100 files. Consider using a more specific pattern.]"
+                );
+            }
+
+            Ok(output)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_glob_basic() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create test files
+        fs::write(temp_path.join("test1.txt"), "content1").unwrap();
+        fs::write(temp_path.join("test2.txt"), "content2").unwrap();
+        fs::write(temp_path.join("test.rs"), "rust code").unwrap();
+
+        let tool = GlobTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "pattern": "*.txt"
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("test1.txt"));
+        assert!(result.contains("test2.txt"));
+        assert!(!result.contains("test.rs"));
+    }
+
+    #[tokio::test]
+    async fn test_glob_recursive() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create nested structure
+        fs::create_dir_all(temp_path.join("src/utils")).unwrap();
+        fs::write(temp_path.join("src/main.rs"), "main").unwrap();
+        fs::write(temp_path.join("src/utils/helper.rs"), "helper").unwrap();
+
+        let tool = GlobTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "pattern": "**/*.rs"
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("main.rs"));
+        assert!(result.contains("helper.rs"));
+    }
+
+    #[tokio::test]
+    async fn test_glob_no_matches() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        let tool = GlobTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "pattern": "*.nonexistent"
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("No files found"));
+    }
+}

--- a/openhands-sdk-rs/src/agent/tools/grep.rs
+++ b/openhands-sdk-rs/src/agent/tools/grep.rs
@@ -1,0 +1,284 @@
+use async_trait::async_trait;
+use regex::Regex;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use super::Tool;
+
+pub struct GrepTool {
+    working_dir: PathBuf,
+}
+
+impl GrepTool {
+    pub fn new(working_dir: PathBuf) -> Self {
+        Self { working_dir }
+    }
+
+    fn search_directory(
+        &self,
+        dir: &Path,
+        pattern: &Regex,
+        include_filter: Option<&Regex>,
+        matches: &mut Vec<(PathBuf, SystemTime)>,
+    ) -> Result<(), String> {
+        if matches.len() >= 100 {
+            return Ok(());
+        }
+
+        let entries = fs::read_dir(dir).map_err(|e| e.to_string())?;
+
+        for entry in entries {
+            if matches.len() >= 100 {
+                break;
+            }
+
+            let entry = entry.map_err(|e| e.to_string())?;
+            let path = entry.path();
+
+            // Skip hidden files and directories
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if name.starts_with('.') {
+                    continue;
+                }
+            }
+
+            if path.is_dir() {
+                // Recurse into subdirectory
+                self.search_directory(&path, pattern, include_filter, matches)?;
+            } else if path.is_file() {
+                // Check include filter
+                if let Some(filter) = include_filter {
+                    if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
+                        if !filter.is_match(filename) {
+                            continue;
+                        }
+                    }
+                }
+
+                // Try to read and search file content
+                if let Ok(content) = fs::read_to_string(&path) {
+                    if pattern.is_match(&content) {
+                        if let Ok(metadata) = fs::metadata(&path) {
+                            if let Ok(modified) = metadata.modified() {
+                                matches.push((path.clone(), modified));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Tool for GrepTool {
+    fn name(&self) -> String {
+        "grep".to_string()
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "Fast content search tool. Searches file contents using regular expressions. \
+            Supports full regex syntax. Filter files by pattern with the include parameter. \
+            Returns matching file paths sorted by modification time. \
+            Only the first 100 results are returned. \
+            Your current working directory is: {}",
+            self.working_dir.display()
+        )
+    }
+
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "The regex pattern to search for in file contents"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Optional directory to search in (defaults to working directory)"
+                },
+                "include": {
+                    "type": "string",
+                    "description": "Optional file pattern to filter which files to search (e.g., '*.js', '*.{ts,tsx}')"
+                }
+            },
+            "required": ["pattern"]
+        })
+    }
+
+    async fn call(&self, args: Value) -> Result<String, String> {
+        let pattern_str = args
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'pattern' argument")?;
+
+        // Compile regex pattern (case-insensitive)
+        let pattern = Regex::new(&format!("(?i){}", pattern_str))
+            .map_err(|e| format!("Invalid regex pattern: {}", e))?;
+
+        let search_path = if let Some(path_str) = args.get("path").and_then(|v| v.as_str()) {
+            PathBuf::from(path_str)
+        } else {
+            self.working_dir.clone()
+        };
+
+        // Validate search path
+        if !search_path.is_dir() {
+            return Err(format!(
+                "Search path '{}' is not a valid directory",
+                search_path.display()
+            ));
+        }
+
+        // Parse include filter if provided
+        let include_filter = if let Some(include_str) = args.get("include").and_then(|v| v.as_str())
+        {
+            // Convert glob pattern to regex
+            let regex_pattern = include_str
+                .replace(".", "\\.")
+                .replace("*", ".*")
+                .replace("{", "(")
+                .replace("}", ")")
+                .replace(",", "|");
+            Some(
+                Regex::new(&format!("^{}$", regex_pattern))
+                    .map_err(|e| format!("Invalid include pattern: {}", e))?,
+            )
+        } else {
+            None
+        };
+
+        // Search for matches
+        let mut matches = Vec::new();
+        self.search_directory(&search_path, &pattern, include_filter.as_ref(), &mut matches)?;
+
+        // Sort by modification time (newest first)
+        matches.sort_by(|a, b| b.1.cmp(&a.1));
+
+        let truncated = matches.len() >= 100;
+        let file_paths: Vec<String> = matches
+            .into_iter()
+            .map(|(path, _)| path.to_string_lossy().to_string())
+            .collect();
+
+        // Format output
+        let include_info = if let Some(inc) = args.get("include").and_then(|v| v.as_str()) {
+            format!(" (filtered by '{}')", inc)
+        } else {
+            String::new()
+        };
+
+        if file_paths.is_empty() {
+            Ok(format!(
+                "No files found containing pattern '{}' in directory '{}'{}",
+                pattern_str,
+                search_path.display(),
+                include_info
+            ))
+        } else {
+            let mut output = format!(
+                "Found {} file(s) containing pattern '{}' in '{}'{}:\n{}",
+                file_paths.len(),
+                pattern_str,
+                search_path.display(),
+                include_info,
+                file_paths.join("\n")
+            );
+
+            if truncated {
+                output.push_str(
+                    "\n\n[Results truncated to first 100 files. Consider using a more specific pattern.]"
+                );
+            }
+
+            Ok(output)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_grep_basic() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create test files
+        fs::write(temp_path.join("file1.txt"), "Hello world").unwrap();
+        fs::write(temp_path.join("file2.txt"), "Goodbye world").unwrap();
+        fs::write(temp_path.join("file3.txt"), "Something else").unwrap();
+
+        let tool = GrepTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "pattern": "world"
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("file1.txt"));
+        assert!(result.contains("file2.txt"));
+        assert!(!result.contains("file3.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_grep_case_insensitive() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("test.txt"), "HELLO WORLD").unwrap();
+
+        let tool = GrepTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "pattern": "hello"
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("test.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_grep_with_include_filter() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("test.txt"), "content").unwrap();
+        fs::write(temp_path.join("test.rs"), "content").unwrap();
+
+        let tool = GrepTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "pattern": "content",
+            "include": "*.rs"
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("test.rs"));
+        assert!(!result.contains("test.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_grep_regex() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("file1.txt"), "error: something failed").unwrap();
+        fs::write(temp_path.join("file2.txt"), "warning: be careful").unwrap();
+
+        let tool = GrepTool::new(temp_path.to_path_buf());
+        let args = serde_json::json!({
+            "pattern": "error.*failed"
+        });
+
+        let result = tool.call(args).await.unwrap();
+        assert!(result.contains("file1.txt"));
+        assert!(!result.contains("file2.txt"));
+    }
+}


### PR DESCRIPTION
- Implemented GlobTool for file pattern matching with recursive search
- Implemented GrepTool for regex-based content search across files
- Implemented FileEditorTool with view, insert, replace, delete, and undo operations
- Implemented ApplyPatchTool for applying unified diff patches
- Added comprehensive test coverage (19 tests, all passing)
- Added dependencies: regex, similar, tempfile (dev)

Closes #2